### PR TITLE
Updating the TextInputbar right button to fade in and out on hiding

### DIFF
--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -516,6 +516,12 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 
     CGFloat rightButtonNewWidth = 0;
     CGFloat rightButtonNewMargin = 0;
+    CGFloat startingAlpha = 1;
+    CGFloat finalAlpha = hidden ? 0 : 1;
+    
+    //Show the button initially so that we can see the button animating
+    self.rightButton.alpha = startingAlpha;
+
     if (!hidden) {
         rightButtonNewWidth = [self.rightButton intrinsicContentSize].width;
         rightButtonNewMargin = self.contentInset.right;
@@ -523,6 +529,7 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
 
     // Only updates if the width did change
     if (self.rightButtonWC.constant == rightButtonNewWidth) {
+        self.rightButton.alpha = finalAlpha;
         return;
     }
 
@@ -533,9 +540,12 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
     BOOL bounces = self.bounces;
 
     if (self.window) {
-        [self slk_animateLayoutIfNeededWithBounce:bounces options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionBeginFromCurrentState|UIViewAnimationOptionAllowUserInteraction animations:NULL];
+        [self slk_animateLayoutIfNeededWithBounce:bounces options:UIViewAnimationOptionCurveEaseInOut|UIViewAnimationOptionBeginFromCurrentState|UIViewAnimationOptionAllowUserInteraction animations:^{
+            self.rightButton.alpha = finalAlpha;
+        } completion: nil];
     }
     else {
+        self.rightButton.alpha = finalAlpha;
         [self layoutIfNeeded];
     }
 


### PR DESCRIPTION
https://jira.trunkclub.com/browse/CEN-2452

This PR addresses the iOS 13 issue where the send button is partially cut off initially on the messaging view.  The solution fades in/out the text as it slides in/out of the view.  There will be two more PRs following this one with the following changes:

- This repo needs an updated release number with these changes and the podspec has to be updated.
- The iOS_truncklub repo will also need a pr to update the podfile to use the newest pod