### PR TITLE
CEN-1337: max textview height & textview content bottom inset

### DIFF
--- a/Examples/Messenger.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/Messenger.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -328,6 +328,9 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
     height -= self.textView.font.lineHeight;
     height += roundf(self.textView.font.lineHeight*numberOfLines);
     height += self.contentInset.top + self.contentInset.bottom;
+    if (height > UIScreen.mainScreen.bounds.size.height * 0.15) {
+        height = UIScreen.mainScreen.bounds.size.height * 0.15;
+    }
 
     return height;
 }

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -668,6 +668,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     }
 
     CGFloat inputbarHeight = _textInputbar.appropriateHeight;
+    _textInputbar.textView.contentInset = UIEdgeInsetsMake(0, 0, 32, 0);
 
     _textInputbar.rightButton.enabled = [self canPressRightButton];
     _textInputbar.editorRightButton.enabled = [self canPressRightButton];


### PR DESCRIPTION
**Ticket**: [CEN-1337](https://jira.trunkclub.com/browse/CEN-1337)

- messaging input textview height is capped at 15% of the screen hight
- added content inset for the input textview so text is not cut off when scrolling is enabled

<img width="387" alt="Screen Shot 2019-12-04 at 11 05 48 AM" src="https://user-images.githubusercontent.com/52932868/70167819-28dd1a00-168d-11ea-8f1a-8f33d5d15bb7.png">